### PR TITLE
Fix case where first comment inside block body would not be indented.

### DIFF
--- a/src/main/kotlin/de/rlang/intellij/alloy/alloy.bnf
+++ b/src/main/kotlin/de/rlang/intellij/alloy/alloy.bnf
@@ -12,7 +12,7 @@
     tokenTypeClass = "de.rlang.intellij.alloy.AlloyTokenType"
 
     tokens = [
-        LINE_COMMENT = "regexp://.*"
+        LINE_COMMENT = "regexp:(//.*)"
         BLOCK_COMMENT = "regexp:/\*([^*]|\*[^/])*\*?(\*/)?"
 
         NUMBER = "regexp:[+-]?(\d*[.])?\d+"

--- a/src/main/kotlin/de/rlang/intellij/alloy/alloy.flex
+++ b/src/main/kotlin/de/rlang/intellij/alloy/alloy.flex
@@ -25,7 +25,7 @@ import static de.rlang.intellij.alloy.AlloyTypes.*;
 EOL=\R
 WHITE_SPACE=\s+
 
-LINE_COMMENT="//".*
+LINE_COMMENT=("//".*)
 BLOCK_COMMENT="/"\*([^*]|\*[^/])*\*?(\*"/")?
 NUMBER=[+-]?([0-9]*[.])?[0-9]+
 IDENTIFIER=[A-Za-z_][A-Za-z_0-9]*

--- a/src/main/kotlin/de/rlang/intellij/alloy/formatter/AlloyBlock.kt
+++ b/src/main/kotlin/de/rlang/intellij/alloy/formatter/AlloyBlock.kt
@@ -3,8 +3,10 @@ package de.rlang.intellij.alloy.formatter
 import com.intellij.formatting.*
 import com.intellij.lang.ASTNode
 import com.intellij.lang.FileASTNode
+import com.intellij.psi.PsiComment
 import com.intellij.psi.TokenType
 import com.intellij.psi.formatter.common.AbstractBlock
+import com.intellij.psi.util.elementType
 import de.rlang.intellij.alloy.AlloyTypes
 
 class AlloyBlock(node: ASTNode, wrap: Wrap?, alignment: Alignment?, private val spacingBuilder: SpacingBuilder) :
@@ -19,7 +21,11 @@ class AlloyBlock(node: ASTNode, wrap: Wrap?, alignment: Alignment?, private val 
             return Indent.getNoneIndent()
         }
 
-        if (node.treeParent.elementType == AlloyTypes.BLOCK_BODY) {
+        if (node.elementType == AlloyTypes.LINE_COMMENT || node.elementType == AlloyTypes.BLOCK_COMMENT) {
+            return Indent.getNormalIndent()
+        }
+
+        if (node.treeParent != null && node.treeParent.elementType == AlloyTypes.BLOCK_BODY) {
             return Indent.getNormalIndent()
         }
         return Indent.getNoneIndent()

--- a/src/test/testData/formatted.alloy
+++ b/src/test/testData/formatted.alloy
@@ -2,14 +2,18 @@
 //Another comment
 
 foo {
+	// before comment
 	foo = "bar"
 	fooo {
 		bar = "foo"
+		// nested comment
 		x = 3 + 7
 	}
 	baaarar {
+		// middle comment
 		foobar {
 			y = 18
 		}
+		// after comment
 	}
 }

--- a/src/test/testData/unformatted.alloy
+++ b/src/test/testData/unformatted.alloy
@@ -2,14 +2,18 @@
 //Another comment
 
 foo {
+// before comment
 foo = "bar"
 fooo {
 bar = "foo"
+// nested comment
 x =  3 + 7
 }
 baaarar {
+// middle comment
 foobar {
 y = 18
 }
+// after comment
 }
 }


### PR DESCRIPTION
Allows the following code block to be properly commented:

```
foo {
	// before comment
}
``` 