### PR TITLE
Add spaces after a line comment on both reformat and code comment.

### DIFF
--- a/src/main/kotlin/de/rlang/intellij/alloy/formatter/AlloyBlock.kt
+++ b/src/main/kotlin/de/rlang/intellij/alloy/formatter/AlloyBlock.kt
@@ -3,10 +3,8 @@ package de.rlang.intellij.alloy.formatter
 import com.intellij.formatting.*
 import com.intellij.lang.ASTNode
 import com.intellij.lang.FileASTNode
-import com.intellij.psi.PsiComment
 import com.intellij.psi.TokenType
 import com.intellij.psi.formatter.common.AbstractBlock
-import com.intellij.psi.util.elementType
 import de.rlang.intellij.alloy.AlloyTypes
 
 class AlloyBlock(node: ASTNode, wrap: Wrap?, alignment: Alignment?, private val spacingBuilder: SpacingBuilder) :

--- a/src/main/kotlin/de/rlang/intellij/alloy/formatter/AlloyCodeStyleSettingsProvider.kt
+++ b/src/main/kotlin/de/rlang/intellij/alloy/formatter/AlloyCodeStyleSettingsProvider.kt
@@ -63,5 +63,7 @@ open class AlloyCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider() 
     ) {
         indentOptions.USE_TAB_CHARACTER = true
         indentOptions.INDENT_SIZE = 4
+        commonSettings.LINE_COMMENT_ADD_SPACE = true
+        commonSettings.LINE_COMMENT_ADD_SPACE_ON_REFORMAT = true
     }
 }

--- a/src/test/kotlin/de/rlang/intellij/alloy/editor/AlloyCommenterTest.kt
+++ b/src/test/kotlin/de/rlang/intellij/alloy/editor/AlloyCommenterTest.kt
@@ -8,7 +8,7 @@ class AlloyCommenterTest : BasePlatformTestCase() {
     fun `test line commenting`() {
         myFixture.configureByText("main.alloy", "<caret>someVariable = \"someValue\"")
         myFixture.performEditorAction(IdeActions.ACTION_COMMENT_LINE)
-        myFixture.checkResult("//someVariable = \"someValue\"")
+        myFixture.checkResult("// someVariable = \"someValue\"")
     }
 
     fun `test line uncommenting`() {

--- a/src/test/kotlin/de/rlang/intellij/alloy/formatter/FormatterTest.kt
+++ b/src/test/kotlin/de/rlang/intellij/alloy/formatter/FormatterTest.kt
@@ -11,15 +11,23 @@ class FormatterTest : FormatterTestCase() {
     }
 
     fun `test adds space before and after equals sign`() {
-        doTextTest("remote_write=http://localhost:9090", "remote_write = http://localhost:9090")
+        doTextTest("remote_write=\"http://localhost:9090\"", "remote_write = \"http://localhost:9090\"")
     }
 
     fun `test does not add additional space around equals sign`() {
-        doTextTest("remote_write = http://localhost:9090", "remote_write = http://localhost:9090")
+        doTextTest("remote_write = \"http://localhost:9090\"", "remote_write = \"http://localhost:9090\"")
     }
 
     override fun getFileExtension(): String {
         return "alloy"
+    }
+
+    fun `test does add space after line comment`() {
+        doTextTest("//some comment", "// some comment")
+    }
+
+    fun `test does not format forward slashes in url`() {
+        doTextTest("// Available at http://localhost:8000", "// Available at http://localhost:8000")
     }
 
 }

--- a/src/test/testData/formatted.alloy
+++ b/src/test/testData/formatted.alloy
@@ -1,5 +1,5 @@
 // Sample comment
-//Another comment
+// Another comment
 
 foo {
 	// before comment


### PR DESCRIPTION
Adds spaces after the line comment like we expect it by setting a `commonConfiguration` from the plugin.

```diff
-//my comment
+// my comment
```

Had to refactor the tests `test does not add additional space around equals sign` and `test adds space before and after equals sign` because they contained previously incorrect syntax, since the url has to be quoted otherwise it will start a comment. 

~~Unfortunatelly, the [documentation is very vague](https://grafana.com/docs/alloy/latest/get-started/configuration-syntax/syntax/#attributes-and-blocks) on what is accepted here, but I'm pretty sure it would start a comment on the alloy file, maybe you can cofirm it @RykoL~~ Actually is [listed somewhere else, that the string must be quoted](https://grafana.com/docs/alloy/latest/get-started/configuration-syntax/expressions/types_and_values/#strings) 

Also removed some imports which were not used.